### PR TITLE
Improve Harpy Chain Lighting

### DIFF
--- a/src/game/scripts/npc/npc_abilities_override.txt
+++ b/src/game/scripts/npc/npc_abilities_override.txt
@@ -291,13 +291,13 @@
 	"harpy_storm_chain_lightning"
 	{
 		"MaxLevel"						"4"
-		"AbilityManaCost"				"50 70 90 100"
+		"AbilityManaCost"				"50 70 90 110"
 		"AbilitySpecial"
 		{
 			"01"
 			{
 				"var_type"				"FIELD_INTEGER"
-				"initial_damage"		"140 240 320 390"
+				"initial_damage"		"140 210 280 350"
 			}
 		}
 	}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/16277198/16975326/8499f9d8-4e88-11e6-9d14-29c507750c43.png)
Rationale: Gave it more damage to chain lighting, but it has a much longer cooldown and jumps to less targets. 
