### PR TITLE
Improve Troll Ensare

### DIFF
--- a/src/game/scripts/npc/npc_abilities_override.txt
+++ b/src/game/scripts/npc/npc_abilities_override.txt
@@ -291,13 +291,13 @@
 	"dark_troll_warlord_ensnare" 
 	{
 		"MaxLevel"						"4"
-		"AbilityManaCost"				"150 170 190 210"
+		"AbilityManaCost"				"150 170 190 250"
 		"AbilitySpecial"
 		{
 			"01"
 			{
 				"var_type"				"FIELD_FLOAT"
-				"duration"				"1.75 3.75 5.75 8.0"
+				"duration"				"1.75 3.75 5.75 7.0"
 			}
 		}
 	}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/16277198/16988872/45c6739c-4ed5-11e6-9114-8013e32c4e91.png)
Rationale: A more costly and more powerful version of Naga's ensare. Has a very long duration in lvl 4 (8 seconds), but has a longer cooldown and manacost at all levels than Naga's. 
