### PR TITLE
Balance Ogre Ice Armor (Nerf and Buff)

### DIFF
--- a/src/game/scripts/npc/npc_abilities_override.txt
+++ b/src/game/scripts/npc/npc_abilities_override.txt
@@ -287,4 +287,43 @@
 	{
 		"RequiredLevel"					"3"
 	}
+	
+	"ogre_magi_frost_armor" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"MaxLevel"						"4"
+		"AbilityCastRange"				"800"
+
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"armor_bonus"			"2 3 4 5"
+			}
+			"02"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"duration"				"45.0 45.0 45.0 45.0"
+			}
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"movespeed_slow"		"-20 -20 -20 -20"
+			}
+			"04"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"attackspeed_slow"		"-20 -30 -40 -50"
+			}
+			"05"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"slow_duration"			"5.0 5.0 5.0 5.0"
+			}
+		}
+	}
 }	


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/16277198/17012749/1db77cc4-4f5d-11e6-81b9-798a7780e006.png)
I changed ogre ice armor quite a bit. I wanted to improve it like the other abilities, but it starts off too powerful (extra 8 armor, and move slow the same as the max of Lich's ice armor) so there was no way to buff it without making it OP.
I changed the ability so it does less movement slow, gives less armor than Lich's, but on the flip-side, it slows attack speed much more and has a longer debuff duration. I figured that having it slow attack speed at the expensive of moveslow and bonus armor may make it useful in LoD where half the players use right-click heros. 
Just for rerfence this is Lich's ice armor. 
![image](https://cloud.githubusercontent.com/assets/16277198/17012811/832d9fca-4f5d-11e6-934c-1e04309559e6.png)

Todo: Recolor Ogre image so that they dont share the same icon. 
