### PR TITLE
Buffer Cherub's Flowers

### DIFF
--- a/script_generator/CUSTOM/npc_units_custom.txt
+++ b/script_generator/CUSTOM/npc_units_custom.txt
@@ -1175,7 +1175,7 @@
 		// Status
 		//----------------------------------------------------------------
 		"StatusHealth"                "250"        // Base health.
-		"StatusHealthRegen"            "3.0"        // Health regeneration rate.
+		"StatusHealthRegen"            "20.0"        // Health regeneration rate.
 		"StatusMana"                "0"            // Base mana.
 		"StatusManaRegen"            "0"            // Mana regeneration rate.
 	
@@ -1237,7 +1237,7 @@
 		// Status
 		//----------------------------------------------------------------
 		"StatusHealth"                "250"        // Base health.
-		"StatusHealthRegen"            "3.0"        // Health regeneration rate.
+		"StatusHealthRegen"            "20.0"        // Health regeneration rate.
 		"StatusMana"                "0"            // Base mana.
 		"StatusManaRegen"            "0"            // Mana regeneration rate.
 	
@@ -1309,7 +1309,7 @@
 		// Status
 		//----------------------------------------------------------------
 		"StatusHealth"                "250"        // Base health.
-		"StatusHealthRegen"            "3.0"        // Health regeneration rate.
+		"StatusHealthRegen"            "20.0"        // Health regeneration rate.
 		"StatusMana"                "0"            // Base mana.
 		"StatusManaRegen"            "0"            // Mana regeneration rate.
 	
@@ -1381,7 +1381,7 @@
 		// Status
 		//----------------------------------------------------------------
 		"StatusHealth"                "250"        // Base health.
-		"StatusHealthRegen"            "3.0"        // Health regeneration rate.
+		"StatusHealthRegen"            "20.0"        // Health regeneration rate.
 		"StatusMana"                "0"            // Base mana.
 		"StatusManaRegen"            "0"            // Mana regeneration rate.
 	
@@ -1443,7 +1443,7 @@
 		// Status
 		//----------------------------------------------------------------
 		"StatusHealth"                "250"        // Base health.
-		"StatusHealthRegen"            "3.0"        // Health regeneration rate.
+		"StatusHealthRegen"            "20.0"        // Health regeneration rate.
 		"StatusMana"                "0"            // Base mana.
 		"StatusManaRegen"            "0"            // Mana regeneration rate.
 	

--- a/src/game/scripts/abilities/cherub_flower_garden.lua
+++ b/src/game/scripts/abilities/cherub_flower_garden.lua
@@ -1,7 +1,7 @@
 function GardenCheck( keys )
     local caster = keys.caster
     local ability = keys.ability
-    local healthCost = caster:GetMaxHealth()/200.0
+    local healthCost = caster:GetMaxHealth()/80.0
     
     if caster:GetHealth() > healthCost then
         caster:ModifyHealth( caster:GetHealth() - healthCost, ability, false, 0 )
@@ -197,7 +197,7 @@ function PlantPink( keys )
     owner.pinkFlowerCount = owner.pinkFlowerCount or 0
     owner.pinkFlowerTable = owner.pinkFlowerTable or {}
     
-    local maxFlowers = 4
+    local maxFlowers = 3
     local casterLocation = caster:GetAbsOrigin()
     if ownerAbility then
         local pinkFlower = CreateUnitByName( "pink_flower", casterLocation, false, owner, owner, owner:GetTeamNumber() )
@@ -225,7 +225,7 @@ function PlantPinkBase( keys )
     owner.pinkFlowerCount = owner.pinkFlowerCount or 0
     owner.pinkFlowerTable = owner.pinkFlowerTable or {}
     
-    local maxFlowers = 4
+    local maxFlowers = 3
     local casterLocation = caster:GetAbsOrigin()
     if ownerAbility then
         local pinkFlower = CreateUnitByName( "pink_flower", point, false, owner, owner, owner:GetTeamNumber() )

--- a/src/game/scripts/npc/npc_abilities_custom.txt
+++ b/src/game/scripts/npc/npc_abilities_custom.txt
@@ -4271,7 +4271,7 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
             "03"
             {
@@ -4286,17 +4286,17 @@
             "05"
             {
                 "var_type"            "FIELD_INTEGER"
-                "pink_flower_heal"        "7 11 15"
+                "pink_flower_heal"        "14 22 30"
             }
             "06"
             {
                 "var_type"            "FIELD_INTEGER"
-                "blue_flower_restore"        "12 16 20"
+                "blue_flower_restore"        "18 22 26"
             }
             "07"
             {
                 "var_type"            "FIELD_INTEGER"
-                "yellow_flower_bonus"        "25 35 50"
+                "yellow_flower_bonus"        "30 40 55"
             }
             "08"
             {
@@ -4306,12 +4306,12 @@
             "09"
             {
                 "var_type"            "FIELD_INTEGER"
-                "white_flower_damage"        "24 32 40"
+                "white_flower_damage"        "44 52 60"
             }
             "10"
             {
                 "var_type"            "FIELD_INTEGER"
-                "red_flower_damage"        "48 64 80"
+                "red_flower_damage"        "68 84 100"
             }
         }
         "precache"
@@ -4761,12 +4761,12 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "white_flower_damage"        "10 20 30 40"
+                "white_flower_damage"        "30 40 50 60"
             }
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "150 250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
         }
         "precache"
@@ -4869,12 +4869,12 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "red_flower_damage"        "20 40 60 80"
+                "red_flower_damage"        "40 60 80 100"
             }
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "150 250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
         }
         "precache"
@@ -4984,12 +4984,12 @@
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "heal_amount"            "6 9 12 15"
+                "heal_amount"            "12 18 24 30"
             }
             "04"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "150 250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
         }
         "precache"
@@ -5118,12 +5118,12 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "restore_amount"        "8 12 16 20"
+                "restore_amount"        "14 18 22 26"
             }
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "150 250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
         }
         "precache"
@@ -5242,12 +5242,12 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "attackspeed_bonus"        "20 30 40 50"
+                "attackspeed_bonus"        "30 40 50 60"
             }
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "150 250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
         }
         "precache"
@@ -5375,7 +5375,7 @@
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "flower_health"            "150 250 350 450"
+                "flower_health"            "400 600 800 1000"
             }
         }
         "precache"
@@ -5494,7 +5494,7 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "restore_amount"        "12 16 20"
+                "restore_amount"        "18 22 26"
             }
         }
         "OnSpellStart"
@@ -5528,7 +5528,7 @@
             "03"
             {
                 "var_type"            "FIELD_INTEGER"
-                "heal_amount"            "7 11 15"
+                "heal_amount"            "14 22 30"
             }
         }
         "OnSpellStart"
@@ -5586,7 +5586,7 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "damage"        "48 64 80"
+                "damage"        "68 84 100"
             }
         }
         "OnSpellStart"
@@ -5615,7 +5615,7 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "damage"        "24 32 40"
+                "damage"        "44 52 60"
             }
         }
         "OnSpellStart"
@@ -5644,7 +5644,7 @@
             "02"
             {
                 "var_type"            "FIELD_INTEGER"
-                "attackspeed_bonus"        "25 35 50"
+                "attackspeed_bonus"        "35 45 60"
             }
         }
         "OnSpellStart"

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -1168,7 +1168,7 @@
     "DOTA_Tooltip_ability_cherub_explosive_spore_Spore_movespeed"  "SPORE MOVEMENT SPEED:"
 
     "DOTA_Tooltip_ability_cherub_flower_garden"      "Flower Garden"
-    "DOTA_Tooltip_ability_cherub_flower_garden_Description"    "Cherub fertilizes the ground, creating a garden plot temporarily. Costs 10%d%% of Cherub's Max health. Cherub can plant any one of six different flowers on her garden plots, which have increased stats based on the level of this ability.\nUpgradable by Aghanim's Scepter."
+    "DOTA_Tooltip_ability_cherub_flower_garden_Description"    "Cherub fertilizes the ground, creating a garden plot temporarily. Costs 25%d%% of Cherub's Max health. Cherub can plant any one of six different flowers on her garden plots, which have increased stats based on the level of this ability.\nUpgradable by Aghanim's Scepter."
     "DOTA_Tooltip_ability_cherub_flower_garden_Note0"      "Each flower has 0 armor and 0%d%% magic resistance."
     "DOTA_Tooltip_ability_cherub_flower_garden_Duration"      "DURATION:"
     "DOTA_Tooltip_ability_cherub_flower_garden_Flower_health"    "FLOWER HEALTH:"
@@ -1187,7 +1187,7 @@
     "DOTA_Tooltip_ability_garden_red_flower_Damage"      "DAMAGE:"
     
     "DOTA_Tooltip_ability_garden_pink_blossom"    "Pink Blossom"
-    "DOTA_Tooltip_ability_garden_pink_blossom_Description"  "Plants a pink blossom which heals three random allies every second. Maximum of 4 flowers. "
+    "DOTA_Tooltip_ability_garden_pink_blossom_Description"  "Plants a pink blossom which heals three random allies every second. Maximum of 3 flowers. "
     "DOTA_Tooltip_ability_garden_pink_blossom_Radius"    "SEARCH RADIUS:"
     "DOTA_Tooltip_ability_garden_pink_blossom_Targets"    "MAX TARGETS:"  
     "DOTA_Tooltip_ability_garden_pink_blossom_Heal_amount"  "HEAL AMOUNT:"  
@@ -1209,38 +1209,38 @@
     
     // Base flowers
     "DOTA_Tooltip_ability_garden_white_flower_base"    "White Flower"
-    "DOTA_Tooltip_ability_garden_white_flower_base_Description"  "Plants a white flower which deals low attack damage from a high range. Maximum of 6 flowers. Costs 10%d%% of your maximum health and requires 2 seconds of channelling to plant."
+    "DOTA_Tooltip_ability_garden_white_flower_base_Description"  "Plants a white flower which deals low attack damage from a high range. Maximum of 6 flowers. Costs 25%d%% of your maximum health and requires 2 seconds of channelling to plant."
     "DOTA_Tooltip_ability_garden_white_flower_base_Range"    "ATTACK RANGE:"
     "DOTA_Tooltip_ability_garden_white_flower_base_White_flower_damage"       "DAMAGE:"
     "DOTA_Tooltip_ability_garden_white_flower_base_Flower_health"    "FLOWER HEALTH:"
 
     "DOTA_Tooltip_ability_garden_red_flower_base"    "Red Flower"
-    "DOTA_Tooltip_ability_garden_red_flower_base_Description"  "Plants a red flower which deals high attack damage from a short range. Maximum of 6 flowers. Costs 10%d%% of your maximum health and requires 2 seconds of channelling to plant. "
+    "DOTA_Tooltip_ability_garden_red_flower_base_Description"  "Plants a red flower which deals high attack damage from a short range. Maximum of 6 flowers. Costs 25%d%% of your maximum health and requires 2 seconds of channelling to plant. "
     "DOTA_Tooltip_ability_garden_red_flower_base_Range"      "ATTACK RANGE:"
     "DOTA_Tooltip_ability_garden_red_flower_base_Red_flower_damage"      "DAMAGE:"
     "DOTA_Tooltip_ability_garden_red_flower_base_Flower_health"    "FLOWER HEALTH:"
     
     "DOTA_Tooltip_ability_garden_pink_blossom_base"    "Pink Blossom"
-    "DOTA_Tooltip_ability_garden_pink_blossom_base_Description"  "Plants a pink blossom which heals three random allies every second. Maximum of 4 flowers. Costs 10%d%% of your maximum health and requires 2 seconds of channelling to plant."
+    "DOTA_Tooltip_ability_garden_pink_blossom_base_Description"  "Plants a pink blossom which heals three random allies every second. Maximum of 3 flowers. Costs 25%d%% of your maximum health and requires 2 seconds of channelling to plant."
     "DOTA_Tooltip_ability_garden_pink_blossom_base_Radius"    "SEARCH RADIUS:"
     "DOTA_Tooltip_ability_garden_pink_blossom_base_Targets"    "MAX TARGETS:"  
     "DOTA_Tooltip_ability_garden_pink_blossom_base_Heal_amount"  "HEAL AMOUNT:"  
     "DOTA_Tooltip_ability_garden_pink_blossom_base_Flower_health"    "FLOWER HEALTH:"
                                                  
     "DOTA_Tooltip_ability_garden_blue_blossom_base"    "Blue Blossom"
-    "DOTA_Tooltip_ability_garden_blue_blossom_base_Description"  "Plants a blue blossom which restores mana in an area every 5 seconds. Maximum of 4 flowers. Costs 10%d%% of your maximum health and requires 2 seconds of channelling to plant."
+    "DOTA_Tooltip_ability_garden_blue_blossom_base_Description"  "Plants a blue blossom which restores mana in an area every 5 seconds. Maximum of 4 flowers. Costs 25%d%% of your maximum health and requires 2 seconds of channelling to plant."
     "DOTA_Tooltip_ability_garden_blue_blossom_base_Radius"    "RADIUS:"
     "DOTA_Tooltip_ability_garden_blue_blossom_base_Restore_amount"  "RESTORE AMOUNT:"
     "DOTA_Tooltip_ability_garden_blue_blossom_base_Flower_health"  "FLOWER HEALTH:"
                                                  
     "DOTA_Tooltip_ability_garden_yellow_daisy_base"    "Yellow Daisy"
-    "DOTA_Tooltip_ability_garden_yellow_daisy_base_Description"  "Plants a yellow daisy which increases attackspeed for nearby allies. Maximum of 2 flowers. Costs 10%d%% of your maximum health and requires 2 seconds of channelling to plant."
+    "DOTA_Tooltip_ability_garden_yellow_daisy_base_Description"  "Plants a yellow daisy which increases attackspeed for nearby allies. Maximum of 2 flowers. Costs 25%d%% of your maximum health and requires 2 seconds of channelling to plant."
     "DOTA_Tooltip_ability_garden_yellow_daisy_base_Radius"    "AURA RADIUS:"
     "DOTA_Tooltip_ability_garden_yellow_daisy_base_Attackspeed_bonus"    "BONUS ATTACKSPEED:"
     "DOTA_Tooltip_ability_garden_yellow_daisy_base_Flower_health"    "FLOWER HEALTH:"
                                                  
     "DOTA_Tooltip_ability_garden_purple_lotus_base"    "Purple Lotus"
-    "DOTA_Tooltip_ability_garden_purple_lotus_base_Description"  "Plants a purple lotus which increases magic resistance for nearby allies. Maximum of 2 flowers. Costs 10%d%% of your maximum health and requires 2 seconds of channelling to plant."
+    "DOTA_Tooltip_ability_garden_purple_lotus_base_Description"  "Plants a purple lotus which increases magic resistance for nearby allies. Maximum of 2 flowers. Costs 25%d%% of your maximum health and requires 2 seconds of channelling to plant."
     "DOTA_Tooltip_ability_garden_purple_lotus_base_Radius"    "AURA RADIUS:"
     "DOTA_Tooltip_ability_garden_purple_lotus_base_resistance"  "%MAGIC RESISTANCE:"
     "DOTA_Tooltip_ability_garden_purple_lotus_base_Flower_health"    "FLOWER HEALTH:"


### PR DESCRIPTION
Flowers have much more health, and they have 20hp/s regen. 
Damage plants do +20 damage at all levels. 
Speed Plant gives 10 more attack speed at all levels. 
Heal plant gives double health. Maximum 3 instead of 4. 
Plants take 25% of the player's health, instead of 10%.
