### PR TITLE
Balance Walrus Kick (Again)

### DIFF
--- a/src/game/scripts/npc/npc_abilities_override.txt
+++ b/src/game/scripts/npc/npc_abilities_override.txt
@@ -288,10 +288,15 @@
 		"MaxLevel"						"4"
 		"AbilitySpecial"
 		{
+			"03"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"push_length"				"300 500 700 900"
+			}
 			"07"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"damage"					"100 250 350 450"
+				"damage"					"100 200 300 400"
 			}
 		}
 	}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/16277198/17446217/8b306b46-5b8b-11e6-9557-65731093feb0.png)
Lowered damage because it was too much at early game. 
