### PR TITLE
Displays Options on Start [WIP]

### DIFF
--- a/src/game/scripts/vscripts/pregame.lua
+++ b/src/game/scripts/vscripts/pregame.lua
@@ -604,6 +604,37 @@ function Pregame:onThink()
         -- Do things after a small delay
         local this = self
 
+        local gameModeTranslation = {
+            "All Pick",
+            "",
+            "Mirror Draft",
+            "All Random",
+            "Single Draft"
+        }
+        Say(nil, string.format("<font color='#FF7800'>%s</font>",
+                               gameModeTranslation[self.optionStore['lodOptionCommonGamemode']]), false)
+        Say(nil, string.format("Heroes will start with <font color='#FF7800'>%d</font> gold, at level <font color='#FF7800'>%d</font>, and can progress up to level <font color='#FF7800'>%d</font>",
+                               self.optionStore['lodOptionGameSpeedStartingGold'],
+                               self.optionStore['lodOptionGameSpeedStartingLevel'],
+                               self.optionStore['lodOptionGameSpeedMaxLevel']), false)
+        Say(nil, string.format("The respawn time is decreased by <font color='#FF7800'>%d</font>%%, with an additional <font color='#FF7800'>%d</font> seconds. Buyback cooldown is set to <font color='#FF7800'>%d</font>.",
+                               100 - self.optionStore['lodOptionGameSpeedRespawnTimePercentage'],
+                               self.optionStore['lodOptionGameSpeedRespawnTimeConstant'],
+                               self.optionStore['lodOptionBuybackCooldownTimeConstant']), false)
+        Say(nil, string.format("There are <font color='#FF7800'>%d%s</font> towers per lane.",
+                               self.optionStore['lodOptionGameSpeedTowersPerLane'],
+                               self.optionStore['lodOptionGameSpeedStrongTowers'] == 1 and " stronger" or ""), false)
+        local others = table.concat({
+            self.optionStore['lodOptionCrazyUniversalShop'] == 1 and "Universal Shop, " or "",
+            self.optionStore['lodOptionCrazyAllVision'] == 1 and "All Vision, " or "",
+            self.optionStore['lodOptionCrazyWTF'] == 1 and "WTF, " or "",
+            self.optionStore['lodOptionCrazyMulticast'] == 1 and "Multicast Madness, " or "",
+            self.optionStore['lodOptionCrazyNoCamping'] == 1 and "Prevent Fountain Camping, " or ""})
+        if others ~= "" then
+            Say(nil, others:sub(1, others:len() - 2), false)
+        end
+        
+
         -- Hook bot stuff
         self:hookBotStuff()
 


### PR DESCRIPTION
WIP:
Custom Abilities

I personally think that we should not display custom abilities. It can easily take up the whole chat space making displaying options on start meaningless.

Todo (Added by Darklord)
- [ ] All the english text has to be in the localization file. 
- [ ] Place the settings display into a function
- [ ] Add command that players can use to see settings "-settings"
- [ ] Improve conditional displaying. As a rule of thumb, only non-default settings should be displayed, for example if the starting level is 1, it should not display that. 
  [Complete list of settings and the conditions required  to display them. ](https://docs.google.com/spreadsheets/d/1n0MdSUmP3pQfEgk0gMVclihHWOrGqBKqzoaRS7wEXOk/edit?usp=sharing)
- [ ] Use "GameRules:SendCustomMessage("", 10, 10)" instead of "say", because say has the "Console:" part. 
  ![image](https://cloud.githubusercontent.com/assets/16277198/17760782/9d46566a-6545-11e6-9845-4b81032e7511.png)
