### PR TITLE
Added cap to Invoker intelligence bonus stacks

### DIFF
--- a/src/game/scripts/vscripts/abilities/hero_perks/npc_dota_hero_invoker_perk.lua
+++ b/src/game/scripts/vscripts/abilities/hero_perks/npc_dota_hero_invoker_perk.lua
@@ -1,7 +1,7 @@
 --------------------------------------------------------------------------------------------------------
 --
 --		Hero: Invoker
---		Perk: Invoker gains +5 intelligence each time he uses a different ability, resetting when an ability has been used twice. 
+--		Perk: Invoker gains +5 intelligence each time he uses a different ability, resetting when an ability has been used twice. Caps at +30 intelligence. 
 --
 --------------------------------------------------------------------------------------------------------
 LinkLuaModifier( "modifier_npc_dota_hero_invoker_perk", "abilities/hero_perks/npc_dota_hero_invoker_perk.lua" ,LUA_MODIFIER_MOTION_NONE )
@@ -25,6 +25,7 @@ end
 function modifier_npc_dota_hero_invoker_perk:OnCreated()
 	self.abilityTable = {}
 	self.intPerAbility = 5
+	self.maxStacks = 30
 end
 
 function modifier_npc_dota_hero_invoker_perk:DeclareFunctions()
@@ -45,7 +46,7 @@ function modifier_npc_dota_hero_invoker_perk:OnAbilityExecuted(params)
 				break
 			end
 		end
-		if params.unit == self:GetParent() and not castAbility and not (params.ability:IsItem() or params.ability:IsToggle()) then
+		if params.unit == self:GetParent() and not castAbility and not (params.ability:IsItem() or params.ability:IsToggle()) and self:GetStackCount() < self.maxStacks then
 			table.insert(self.abilityTable, params.ability)
 			self:SetStackCount(self:GetStackCount() + self.intPerAbility)
 		elseif castAbility then


### PR DESCRIPTION
With true random abilities it can stack ridiculously high, so I added a cap of 30 (6 abilities). 
