### PR TITLE
Fixes and balances.

### DIFF
--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_symbiotic.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_symbiotic.txt
@@ -22,7 +22,7 @@
   			"01"
   			{
   				"var_type"                  "FIELD_INTEGER"
-  				"bonus"						"15 30 45"
+  				"bonus"						"5 10 15"
   			}
   		}
   		"precache"

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/ability.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/ability.lua
@@ -14,7 +14,6 @@ function spell_lab_symbiotic:GetBehavior()
 end
 
 function spell_lab_symbiotic:OnSpellStart()
-
 	if self:GetCaster():HasModifier("spell_lab_symbiotic_modifier") then
 		self:EndSymbiosis()
 	else

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/modifier.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/modifier.lua
@@ -9,6 +9,7 @@ function spell_lab_symbiotic_modifier:OnCreated( kv )
     self.scale = self:GetParent():GetModelScale()
     self:GetParent():SetModelScale(0.001)
 	end
+	--self.hasScepter = self:GetParent():HasScepter()
 end
 
 function spell_lab_symbiotic_modifier:SetHost (hTarget,hMod)
@@ -34,7 +35,8 @@ function spell_lab_symbiotic_modifier:DeclareFunctions()
     MODIFIER_EVENT_ON_SET_LOCATION,
 		MODIFIER_EVENT_ON_TAKEDAMAGE,
 		MODIFIER_EVENT_ON_DEATH,
-    MODIFIER_PROPERTY_INVISIBILITY_LEVEL
+    MODIFIER_PROPERTY_INVISIBILITY_LEVEL,
+		MODIFIER
 	}
 	return funcs
 end
@@ -60,7 +62,7 @@ function spell_lab_symbiotic_modifier:CheckState()
   [MODIFIER_STATE_NOT_ON_MINIMAP] = true,
   [MODIFIER_STATE_NO_HEALTH_BAR] = true,
   [MODIFIER_STATE_FROZEN] = true,
-  --[MODIFIER_STATE_DISARMED] = true,
+  [MODIFIER_STATE_DISARMED] = not self:GetParent():HasScepter(),
   [MODIFIER_STATE_OUT_OF_GAME] = true,
   [MODIFIER_STATE_TRUESIGHT_IMMUNE] = true,
   [MODIFIER_STATE_INVISIBLE] = true
@@ -111,6 +113,7 @@ end
 
 function spell_lab_symbiotic_modifier:OnIntervalThink()
 	if IsServer() then
+		if not self:GetParent():IsAlive() then self:Terminate(nil) end
     if self.hHost == nil then return end
     local hParent = self:GetParent()
     local mana = (self.hHost:GetMana() / self.hHost:GetMaxMana()) * hParent:GetMaxMana()

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/target.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/target.lua
@@ -17,16 +17,18 @@ end
 
 function spell_lab_symbiotic_target:InitSymbiot (hModifier)
 	if IsServer() then
-    self.symbiot = hModifier;
+		self.symbiot = hModifier
 	end
 end
 
 function spell_lab_symbiotic_target:DeclareFunctions()
 	local funcs = {
-    MODIFIER_EVENT_ON_DEATH,
+    MODIFIER_EVENT_ON_DEATH--[[]]--
+		,
     MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
     MODIFIER_PROPERTY_STATS_AGILITY_BONUS,
     MODIFIER_PROPERTY_STATS_INTELLECT_BONUS
+		--]]--
 	}
 	return funcs
 end

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -7772,8 +7772,9 @@
         "DOTA_Tooltip_ability_spawnlord_master_freeze_creep_damage"       "PETRIFY DPS:"
 
         "DOTA_Tooltip_ability_spell_lab_symbiotic"                                      "Arcane Symbiosis"
-        "DOTA_Tooltip_ability_spell_lab_symbiotic_Description" "You bind yourself to target allied hero. You may attack and cast spells as normal but you share manapool. If your symbiotic host dies, you die as well.\nMana pool is shared as percentages.\nWhen host takes damage ending symbiosis is put on 3s cooldown.\nHost hero is granted bonus to all stats."
+        "DOTA_Tooltip_ability_spell_lab_symbiotic_Description" "You bind yourself to target allied hero. You may cast spells as normal but you share manapool. If your symbiotic host dies, you die as well.\nMana pool is shared as percentages.\nWhen host takes damage ending symbiosis is put on 3s cooldown.\nHost hero is granted bonus to all stats."
         "DOTA_Tooltip_ability_spell_lab_symbiotic_bonus" "+$all"
+		"DOTA_Tooltip_ability_spell_lab_symbiotic_Aghanim_Description"	"Allows you to attack while in symbiosis."
         "DOTA_Tooltip_spell_lab_symbiotic_modifier" "Arcance Symbiosis"
         "DOTA_Tooltip_spell_lab_symbiotic_modifier_Description" "You share mana pool with a host hero."
         "DOTA_Tooltip_spell_lab_symbiotic_target"   "Arcance Symbiosis: Host"


### PR DESCRIPTION
Herobuilder should now remove the buff from a host hero correctly.
Balance changes:
reduced stat bonuses from 15/30/45 to 5/10/15
requires aghanims scepter to be able to attack while in symbiosis.