### PR TITLE
Balancing and fixing arcane symbiosis

### DIFF
--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_symbiotic.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_symbiotic.txt
@@ -23,7 +23,27 @@
   			"01"
   			{
   				"var_type"                  "FIELD_INTEGER"
-  				"bonus"						"5 10 15"
+  				"bonus"						"5 8 11"
+  			}
+  			"02"
+  			{
+  				"var_type"                  "FIELD_INTEGER"
+  				"mana_regen"						"70 100 130"
+  			}
+  			"03"
+  			{
+  				"var_type"                  "FIELD_FLOAT"
+  				"vis_duration"						"3.0 2.5 2.0"
+  			}
+  			"04"
+  			{
+  				"var_type"                  "FIELD_FLOAT"
+  				"magic_armor"						"-10.0 -12.5 -15.0"
+  			}
+  			"05"
+  			{
+  				"var_type"                  "FIELD_FLOAT"
+  				"physical_armor"						"-5.0 -6.5 -8.0"
   			}
   		}
   		"precache"

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/ability.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/ability.lua
@@ -26,6 +26,7 @@ function spell_lab_symbiotic:CastFilterResultTarget( hTarget )
 	local nTargetID = hTarget:GetPlayerOwnerID()
 	if self:GetCaster() == hTarget then return UF_FAIL_CUSTOM end
 		if self:GetCaster():HasModifier("spell_lab_symbiotic_target") then return UF_FAIL_CUSTOM end
+			if hTarget:HasAbility("life_stealer_infest") then return UF_FAIL_CUSTOM end
 	if IsServer() and not hTarget:IsOpposingTeam(self:GetCaster():GetTeamNumber()) and PlayerResource:IsDisableHelpSetForPlayerID(nTargetID,nCasterID) then
 		return UF_FAIL_DISABLE_HELP
 	end
@@ -39,6 +40,7 @@ end
 
 function spell_lab_symbiotic:GetCustomCastErrorTarget(hTarget)
 if self:GetCaster() == hTarget then return "#DOTA_Error_spell_lab_symbiotic_no_self_target" end
+	if hTarget:HasAbility("life_stealer_infest") then return "#DOTA_Error_spell_lab_symbiotic_no_infest_target" end
 	if self:GetCaster():HasModifier("spell_lab_symbiotic_target") then return "#DOTA_Error_spell_lab_symbiotic_no_inception" end
 end
 function spell_lab_symbiotic:StartSymbiosis(hTarget)
@@ -54,4 +56,5 @@ end
 function spell_lab_symbiotic:EndSymbiosis()
 	local hSymbiot = self:GetCaster():FindModifierByName("spell_lab_symbiotic_modifier")
 	hSymbiot:Terminate(nil)
+	self:EndCooldown()
 end

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/ability.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/ability.lua
@@ -26,7 +26,10 @@ function spell_lab_symbiotic:CastFilterResultTarget( hTarget )
 	local nTargetID = hTarget:GetPlayerOwnerID()
 	if self:GetCaster() == hTarget then return UF_FAIL_CUSTOM end
 		if self:GetCaster():HasModifier("spell_lab_symbiotic_target") then return UF_FAIL_CUSTOM end
-			if hTarget:HasAbility("life_stealer_infest") then return UF_FAIL_CUSTOM end
+		if hTarget:IsCourier() then
+			return UF_SUCCESS
+		end
+		--	if hTarget:HasAbility("life_stealer_infest") then return UF_FAIL_CUSTOM end
 	if IsServer() and not hTarget:IsOpposingTeam(self:GetCaster():GetTeamNumber()) and PlayerResource:IsDisableHelpSetForPlayerID(nTargetID,nCasterID) then
 		return UF_FAIL_DISABLE_HELP
 	end
@@ -40,7 +43,7 @@ end
 
 function spell_lab_symbiotic:GetCustomCastErrorTarget(hTarget)
 if self:GetCaster() == hTarget then return "#DOTA_Error_spell_lab_symbiotic_no_self_target" end
-	if hTarget:HasAbility("life_stealer_infest") then return "#DOTA_Error_spell_lab_symbiotic_no_infest_target" end
+	--if hTarget:HasAbility("life_stealer_infest") then return "#DOTA_Error_spell_lab_symbiotic_no_infest_target" end
 	if self:GetCaster():HasModifier("spell_lab_symbiotic_target") then return "#DOTA_Error_spell_lab_symbiotic_no_inception" end
 end
 function spell_lab_symbiotic:StartSymbiosis(hTarget)

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/modifier.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/modifier.lua
@@ -5,7 +5,7 @@ end
 function spell_lab_symbiotic_modifier:OnCreated( kv )
 	if IsServer() then
     --self.hHost = kv.target:GetParent()
-    self:StartIntervalThink(0.003)
+    self:StartIntervalThink(0.03)
     self.scale = self:GetParent():GetModelScale()
     self:GetParent():SetModelScale(0.001)
 	end
@@ -32,11 +32,11 @@ function spell_lab_symbiotic_modifier:DeclareFunctions()
     --MODIFIER_PROPERTY_MODEL_CHANGE,
   --  MODIFIER_PROPERTY_MODEL_SCALE,
     MODIFIER_EVENT_ON_SPENT_MANA,
+		MODIFIER_EVENT_ON_MANA_GAINED,
     MODIFIER_EVENT_ON_SET_LOCATION,
 		MODIFIER_EVENT_ON_TAKEDAMAGE,
 		MODIFIER_EVENT_ON_DEATH,
-    MODIFIER_PROPERTY_INVISIBILITY_LEVEL,
-		MODIFIER
+    MODIFIER_PROPERTY_INVISIBILITY_LEVEL
 	}
 	return funcs
 end
@@ -103,6 +103,9 @@ function spell_lab_symbiotic_modifier:OnSpentMana (kv)
     self.hHost:SetMana(mana);
 	end
 end
+function spell_lab_symbiotic_modifier:OnManaGained (kv)
+	self:OnSpentMana(kv)
+end
 
 function spell_lab_symbiotic_modifier:Terminate (attacker)
   if attacker then
@@ -116,8 +119,6 @@ function spell_lab_symbiotic_modifier:OnIntervalThink()
 		if not self:GetParent():IsAlive() then self:Terminate(nil) end
     if self.hHost == nil then return end
     local hParent = self:GetParent()
-    local mana = (self.hHost:GetMana() / self.hHost:GetMaxMana()) * hParent:GetMaxMana()
-    hParent:SetMana(mana)
     local pos = self.hHost:GetAbsOrigin()
     local up = Vector(0,0,300)
     hParent:SetAbsOrigin(pos+up)

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/modifier.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/modifier.lua
@@ -5,7 +5,7 @@ end
 function spell_lab_symbiotic_modifier:OnCreated( kv )
 	if IsServer() then
     --self.hHost = kv.target:GetParent()
-    self:StartIntervalThink(0.03)
+    self:StartIntervalThink(0.003)
     self.scale = self:GetParent():GetModelScale()
     self:GetParent():SetModelScale(0.001)
 	end
@@ -32,11 +32,12 @@ function spell_lab_symbiotic_modifier:DeclareFunctions()
     --MODIFIER_PROPERTY_MODEL_CHANGE,
   --  MODIFIER_PROPERTY_MODEL_SCALE,
     MODIFIER_EVENT_ON_SPENT_MANA,
-		MODIFIER_EVENT_ON_MANA_GAINED,
     MODIFIER_EVENT_ON_SET_LOCATION,
 		MODIFIER_EVENT_ON_TAKEDAMAGE,
 		MODIFIER_EVENT_ON_DEATH,
-    MODIFIER_PROPERTY_INVISIBILITY_LEVEL
+    MODIFIER_PROPERTY_INVISIBILITY_LEVEL,
+		MODIFIER_EVENT_ON_ATTACK_LANDED,
+		MODIFIER_EVENT_ON_ABILITY_EXECUTED
 	}
 	return funcs
 end
@@ -89,22 +90,33 @@ function spell_lab_symbiotic_modifier:OnSetLocation (kv)
 	if IsServer() then
 		if kv.unit ~= self:GetParent() then return end
     --DeepPrintTable(kv)
-    if self.hHost ~= nil then
-      FindClearSpaceForUnit(self.hHost,self:GetParent():GetOrigin(),true)
-    end
+		local nCasterID = self:GetCaster():GetPlayerOwnerID()
+		local nTargetID = self:GetParent():GetPlayerOwnerID()
+		if PlayerResource:IsDisableHelpSetForPlayerID(nTargetID,nCasterID) then
+			if self:GetAbility():IsCooldownReady() then
+				self:Terminate(nil)
+			end
+		else
+	    if self.hHost ~= nil and not self.hHost:HasModifier("modifier_life_stealer_infest") then
+	      FindClearSpaceForUnit(self.hHost,self:GetParent():GetOrigin(),true)
+	    end
+		end
   end
 end
 function spell_lab_symbiotic_modifier:OnSpentMana (kv)
 	if IsServer() then
 		if kv.unit ~= self:GetParent() then return end
     if self.hHost == nil then return end
-    local hParent = self:GetParent()
-    local mana = (hParent:GetMana() / hParent:GetMaxMana()) * self.hHost:GetMaxMana()
-    self.hHost:SetMana(mana);
+		local nCasterID = self:GetCaster():GetPlayerOwnerID()
+		local nTargetID = self:GetParent():GetPlayerOwnerID()
+		if PlayerResource:IsDisableHelpSetForPlayerID(nTargetID,nCasterID) and self:GetAbility():IsCooldownReady() then
+			self:Terminate(nil)
+		else
+	    local hParent = self:GetParent()
+	    local mana = (hParent:GetMana() / hParent:GetMaxMana()) * self.hHost:GetMaxMana()
+	    self.hHost:SetMana(mana);
+		end
 	end
-end
-function spell_lab_symbiotic_modifier:OnManaGained (kv)
-	self:OnSpentMana(kv)
 end
 
 function spell_lab_symbiotic_modifier:Terminate (attacker)
@@ -114,11 +126,30 @@ function spell_lab_symbiotic_modifier:Terminate (attacker)
   self:Destroy()
 end
 
+function spell_lab_symbiotic_modifier:OnAttackLanded (kv)
+	if IsServer() then
+		if kv.attacker ~= self:GetParent() then return end
+    if self.hHost == nil then return end
+		self.hMod:Show(self:GetAbility():GetSpecialValueFor("vis_duration"))
+	end
+end
+
+function spell_lab_symbiotic_modifier:OnAbilityExecuted (kv)
+	if IsServer() then
+		if kv.unit ~= self:GetParent() then return end
+    if self.hHost == nil then return end
+		self.hMod:Show(self:GetAbility():GetSpecialValueFor("vis_duration"))
+	end
+end
+
+
 function spell_lab_symbiotic_modifier:OnIntervalThink()
 	if IsServer() then
 		if not self:GetParent():IsAlive() then self:Terminate(nil) end
     if self.hHost == nil then return end
     local hParent = self:GetParent()
+    local mana = (self.hHost:GetMana() / self.hHost:GetMaxMana()) * hParent:GetMaxMana()
+    hParent:SetMana(mana)
     local pos = self.hHost:GetAbsOrigin()
     local up = Vector(0,0,300)
     hParent:SetAbsOrigin(pos+up)

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/target.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/target.lua
@@ -15,12 +15,12 @@ function spell_lab_symbiotic_target:OnDestroy()
 	end
 end
 
-function spell_lab_symbiotic_target:InitSymbiot (hModifier,hSymbiot)
+function spell_lab_symbiotic_target:InitSymbiot (hModifier)
 	if IsServer() then
-		self.hSymbiot = hSymbiot
-		self.hMod = hModifier
+		self.symbiot = hModifier
 	end
 end
+
 
 function spell_lab_symbiotic_target:DeclareFunctions()
 	local funcs = {
@@ -28,7 +28,10 @@ function spell_lab_symbiotic_target:DeclareFunctions()
 		,
     MODIFIER_PROPERTY_STATS_STRENGTH_BONUS,
     MODIFIER_PROPERTY_STATS_AGILITY_BONUS,
-    MODIFIER_PROPERTY_STATS_INTELLECT_BONUS
+    MODIFIER_PROPERTY_STATS_INTELLECT_BONUS,
+		MODIFIER_PROPERTY_MANA_REGEN_PERCENTAGE,
+		MODIFIER_PROPERTY_MAGICAL_RESISTANCE_BONUS,
+		MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS
 		--]]--
 	}
 	return funcs
@@ -41,13 +44,18 @@ end
 function spell_lab_symbiotic_target:OnDeath (kv)
 	if IsServer() then
   if kv.unit ~= self:GetParent() then return end
-  if self.hMod ~= nil then
-    self.hMod:Terminate(kv.attacker)
+  if self.symbiot ~= nil then
+    self.symbiot:Terminate(kv.attacker)
   end
 end
 end
 function spell_lab_symbiotic_target:GetAttributes()
 	return MODIFIER_ATTRIBUTE_IGNORE_INVULNERABLE + MODIFIER_ATTRIBUTE_MULTIPLE + MODIFIER_ATTRIBUTE_PERMANENT
+end
+function spell_lab_symbiotic_target:Show (time)
+	if self:GetParent():IsInvisible() then
+		self:GetParent():AddNewModifier(self:GetCaster(),self:GetAbility(),"modifier_item_dustofappearance",{duration = time})
+	end
 end
 
 function spell_lab_symbiotic_target:AllowIllusionDuplicate()
@@ -67,5 +75,22 @@ end
 function spell_lab_symbiotic_target:GetModifierBonusStats_Intellect()
 	if self:GetAbility() then
 		return self:GetAbility():GetSpecialValueFor("bonus")
+	end
+end
+
+function spell_lab_symbiotic_target:GetModifierPercentageManaRegen ()
+	if self:GetAbility() then
+		return self:GetAbility():GetSpecialValueFor("mana_regen")
+	end
+end
+
+function spell_lab_symbiotic_target:GetModifierPhysicalArmorBonus ()
+	if self:GetAbility() then
+		return self:GetAbility():GetSpecialValueFor("physical_armor")
+	end
+end
+function spell_lab_symbiotic_target:GetModifierMagicalResistanceBonus ()
+	if self:GetAbility() then
+		return self:GetAbility():GetSpecialValueFor("magic_armor")
 	end
 end

--- a/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/target.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/symbiotic/target.lua
@@ -15,9 +15,10 @@ function spell_lab_symbiotic_target:OnDestroy()
 	end
 end
 
-function spell_lab_symbiotic_target:InitSymbiot (hModifier)
+function spell_lab_symbiotic_target:InitSymbiot (hModifier,hSymbiot)
 	if IsServer() then
-		self.symbiot = hModifier
+		self.hSymbiot = hSymbiot
+		self.hMod = hModifier
 	end
 end
 
@@ -40,8 +41,8 @@ end
 function spell_lab_symbiotic_target:OnDeath (kv)
 	if IsServer() then
   if kv.unit ~= self:GetParent() then return end
-  if self.symbiot ~= nil then
-    self.symbiot:Terminate(kv.attacker)
+  if self.hMod ~= nil then
+    self.hMod:Terminate(kv.attacker)
   end
 end
 end

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -7840,6 +7840,7 @@
         "DOTA_Tooltip_spell_lab_symbiotic_target_Description" "You share mana pool with a symbiot hero.\nGrants bonus stats."
         "DOTA_Error_spell_lab_symbiotic_no_self_target" "No self cast."
         "DOTA_Error_spell_lab_symbiotic_no_inception" "Can't cast while being host."
+        "DOTA_Error_spell_lab_symbiotic_no_infest_target" "Can't cast at Hero with ability: Infest"
 
         "DOTA_Tooltip_ability_item_bag_of_gold"                             "Bag of Gold"
         "DOTA_Tooltip_Ability_item_health_potion"                           "Health Potion"

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -7831,16 +7831,21 @@
         "DOTA_Tooltip_ability_spawnlord_master_freeze_creep_damage"       "PETRIFY DPS:"
 
         "DOTA_Tooltip_ability_spell_lab_symbiotic"                                      "Arcane Symbiosis"
-        "DOTA_Tooltip_ability_spell_lab_symbiotic_Description" "You bind yourself to target allied hero. You may cast spells as normal but you share manapool. If your symbiotic host dies, you die as well.\nMana pool is shared as percentages.\nWhen host takes damage ending symbiosis is put on 3s cooldown.\nHost hero is granted bonus to all stats.\n\n Upgradeable by Aghanim's Scepter"
-        "DOTA_Tooltip_ability_spell_lab_symbiotic_bonus" "STAT BONUS:"
+        "DOTA_Tooltip_ability_spell_lab_symbiotic_Description" "You bind yourself to target allied hero. You may cast spells as normal but you share manapool. If your symbiotic host dies, you die as well.\nMana pool is shared as percentages.\nWhen host takes damage ending symbiosis is put on 3s cooldown.\nHost hero is granted bonus to all stats and mana regen while reducing magic resistance and armor.\n\n Upgradeable by Aghanim's Scepter"
+        "DOTA_Tooltip_ability_spell_lab_symbiotic_Note0"           "Temporarily breaks invisibility of host when you cast spell or attack. 3s/2.5s/2s"
+        
+		"DOTA_Tooltip_ability_spell_lab_symbiotic_bonus" "BONUS STAT:"
+		"DOTA_Tooltip_ability_spell_lab_symbiotic_mana_regen" "%BONUS MANA REGEN"
+		"DOTA_Tooltip_ability_spell_lab_symbiotic_magic_armor" "%MAGIC RESISTANCE REDUCTION:"
+		"DOTA_Tooltip_ability_spell_lab_symbiotic_physical_armor" "ARMOR REDUCTION:"
+		
 		"DOTA_Tooltip_ability_spell_lab_symbiotic_Aghanim_Description"	"Allows you to attack while in symbiosis."
         "DOTA_Tooltip_spell_lab_symbiotic_modifier" "Arcance Symbiosis"
         "DOTA_Tooltip_spell_lab_symbiotic_modifier_Description" "You share mana pool with a host hero."
         "DOTA_Tooltip_spell_lab_symbiotic_target"   "Arcance Symbiosis: Host"
-        "DOTA_Tooltip_spell_lab_symbiotic_target_Description" "You share mana pool with a symbiot hero.\nGrants bonus stats."
+        "DOTA_Tooltip_spell_lab_symbiotic_target_Description" "You share mana pool with a symbiot hero.\nGrants bonus stats and mana regen.\nReduces armor and magic resistance.\n\n<br><br>You may disable help from your symbiot to forcefully end the symbiosis when possible."
         "DOTA_Error_spell_lab_symbiotic_no_self_target" "No self cast."
         "DOTA_Error_spell_lab_symbiotic_no_inception" "Can't cast while being host."
-        "DOTA_Error_spell_lab_symbiotic_no_infest_target" "Can't cast at Hero with ability: Infest"
 
         "DOTA_Tooltip_ability_item_bag_of_gold"                             "Bag of Gold"
         "DOTA_Tooltip_Ability_item_health_potion"                           "Health Potion"


### PR DESCRIPTION
-armor and magic reistance reduction for a host.
-mana regen bonus for host.
-added some griefing protection for a host with "disable help"
-fixed infested unit inception blinking: doesn't cause weird issues when teleporting/blinking anymore, it just disables the interaction.
-attacking and casting spells apply dust modifier on the host if host is invisible for 3s/2.5s/2s.
-removed cooldown when manually ending the symbiosis.
-added "secret" clause in targeting filter to let player infest courier... (psst! They don't have mana! You can't get out! :D)
