### PR TITLE
Added missing sounds and particles to Jingu Mastery

### DIFF
--- a/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod.txt
+++ b/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod.txt
@@ -10,8 +10,12 @@
         "AbilityTextureName"                                                   "monkey_king_jingu_mastery"
         "precache"
         {
-            "particle"                                                     "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_overhead.vpcf"
-        }
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_overhead.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_stack.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_start.vpcf"
+            "soundfile" "soundevents/game_sounds_heroes/game_sounds_monkey_king.vsndevts"
+		}
         "AbilitySpecial"
         {
             "01"
@@ -78,21 +82,6 @@
                         "ScriptFile"                           "abilities/epic_boss_fight/monkey_king.lua"
                         "Function"                             "JinguHit"
                         "particle"                             "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
-                    }
-                    "FireEffect"
-                    {
-                        "EffectName"                           "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
-                        "EffectAttachType"                     "attach_hitloc"
-                        "Target"                               "TARGET"
-                        "ControlPointEntities"
-                        {
-                            "TARGET"                       "attach_hitloc"
-                        }
-                    }
-                    "Lifesteal"
-                    {
-                        "Target"                               "ATTACKER"
-                        "LifestealPercent"                     "%lifesteal"
                     }
                 }
             }

--- a/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod.txt
+++ b/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod.txt
@@ -15,7 +15,7 @@
             "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_stack.vpcf"
             "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_start.vpcf"
             "soundfile" "soundevents/game_sounds_heroes/game_sounds_monkey_king.vsndevts"
-		}
+	}
         "AbilitySpecial"
         {
             "01"
@@ -82,7 +82,8 @@
                         "ScriptFile"                           "abilities/epic_boss_fight/monkey_king.lua"
                         "Function"                             "JinguHit"
                         "particle"                             "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
-                    }
+                    	"attack_damage"                        "%attack_damage"
+		    }
                 }
             }
             "modifier_jingu_mastery_hitcount"

--- a/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_melee.txt
+++ b/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_melee.txt
@@ -10,7 +10,11 @@
         "AbilityTextureName"                                                   "custom/monkey_king_jingu_mastery_lod_melee"
         "precache"
         {
-            "particle"                                                     "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_overhead.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_overhead.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_stack.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_start.vpcf"
+            "soundfile" "soundevents/game_sounds_heroes/game_sounds_monkey_king.vsndevts"
         }
         "AbilitySpecial"
         {
@@ -79,21 +83,6 @@
                         "Function"                             "JinguHit"
                         "particle"                             "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
                     }
-                    "FireEffect"
-                    {
-                        "EffectName"                           "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
-                        "EffectAttachType"                     "attach_hitloc"
-                        "Target"                               "TARGET"
-                        "ControlPointEntities"
-                        {
-                            "TARGET"                       "attach_hitloc"
-                        }
-                    }
-                    "Lifesteal"
-                    {
-                        "Target"                               "ATTACKER"
-                        "LifestealPercent"                     "%lifesteal"
-                    }
                 }
             }
             "modifier_jingu_mastery_hitcount"
@@ -118,6 +107,8 @@
                 }
             }
         }
+        "ReduxFlags"                                                           "attack_modifier"
+        "ReduxPerks"                                                           "attack_modifier"
         "ReduxCost"                                                            "40"
     }
 }

--- a/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_melee.txt
+++ b/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_melee.txt
@@ -82,6 +82,7 @@
                         "ScriptFile"                           "abilities/epic_boss_fight/monkey_king.lua"
                         "Function"                             "JinguHit"
                         "particle"                             "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
+                        "attack_damage"                        "%attack_damage"
                     }
                 }
             }

--- a/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_ranged.txt
+++ b/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_ranged.txt
@@ -10,7 +10,11 @@
         "AbilityTextureName"                                                   "custom/monkey_king_jingu_mastery_lod_melee"
         "precache"
         {
-            "particle"                                                     "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_overhead.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_overhead.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_stack.vpcf"
+            "particle" "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_start.vpcf"
+            "soundfile" "soundevents/game_sounds_heroes/game_sounds_monkey_king.vsndevts"
         }
         "AbilitySpecial"
         {
@@ -78,21 +82,6 @@
                         "ScriptFile"                           "abilities/epic_boss_fight/monkey_king.lua"
                         "Function"                             "JinguHit"
                         "particle"                             "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
-                    }
-                    "FireEffect"
-                    {
-                        "EffectName"                           "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
-                        "EffectAttachType"                     "attach_hitloc"
-                        "Target"                               "TARGET"
-                        "ControlPointEntities"
-                        {
-                            "TARGET"                       "attach_hitloc"
-                        }
-                    }
-                    "Lifesteal"
-                    {
-                        "Target"                               "ATTACKER"
-                        "LifestealPercent"                     "%lifesteal"
                     }
                 }
             }

--- a/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_ranged.txt
+++ b/src/game/scripts/npc/abilities/dota/monkey_king_jingu_mastery_lod_ranged.txt
@@ -82,6 +82,7 @@
                         "ScriptFile"                           "abilities/epic_boss_fight/monkey_king.lua"
                         "Function"                             "JinguHit"
                         "particle"                             "particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf"
+                        "attack_damage"                        "%attack_damage"
                     }
                 }
             }

--- a/src/game/scripts/vscripts/abilities/epic_boss_fight/monkey_king.lua
+++ b/src/game/scripts/vscripts/abilities/epic_boss_fight/monkey_king.lua
@@ -1,6 +1,27 @@
 function JinguHit(keys)
 	local caster = keys.caster
 	local ability = keys.ability
+	local target = keys.target
+	local damage = keys.attack_damage
+	
+	--dont think this lifesteal accounts for % based reductions like dispersion
+	if not target:IsBuilding() then
+		-- damage is pre mitigation so we calculate damage post mitigation for lifesteal
+		local armor = target:GetPhysicalArmorValue()
+		local reduction = ((0.02 * armor) / (1 + 0.02 * armor))
+		local lifesteal = (damage - damage * reduction) * ability:GetSpecialValueFor("lifesteal")*0.01
+
+		-- lifesteal pfx and heal
+		local lifePfx = ParticleManager:CreateParticle("particles/generic_gameplay/generic_lifesteal.vpcf", PATTACH_OVERHEAD_FOLLOW, caster)
+	--	ParticleManager:SetParticleControl(lifePfx, 0, caster:GetAbsOrigin())
+		ParticleManager:ReleaseParticleIndex(lifePfx)
+		caster:Heal(lifesteal, caster)
+
+		-- explosion particles on target
+		local hitPfx = ParticleManager:CreateParticle("particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_hit.vpcf", PATTACH_ABSORIGIN_FOLLOW, target)
+		ParticleManager:SetParticleControl(hitPfx, 1, target:GetAbsOrigin())
+		ParticleManager:ReleaseParticleIndex(hitPfx)
+	end
 	
 	local jinguBuff = caster:FindModifierByName("modifier_jingu_mastery_activated")
 	if jinguBuff then
@@ -26,14 +47,15 @@ function CheckJingu(keys)
 	if caster:HasModifier("modifier_jingu_mastery_activated") or not target:IsRealHero() or not caster:IsRealHero() or caster:PassivesDisabled() then return
 	else
 		local jinguStack = target:FindModifierByName("modifier_jingu_mastery_hitcount")
-		if not jinguStack then 
-			ability:ApplyDataDrivenModifier(caster, target, "modifier_jingu_mastery_hitcount", {duration = ability:GetTalentSpecialValueFor("counter_duration")})
-			jinguStack = target:FindModifierByName("modifier_jingu_mastery_hitcount")
+		if jinguStack then
+			jinguStack:ForceRefresh()
+		else
+			jinguStack = ability:ApplyDataDrivenModifier(caster, target, "modifier_jingu_mastery_hitcount", {duration = ability:GetTalentSpecialValueFor("counter_duration")})
 			jinguStack:SetStackCount(0)
-			
 		end
 		jinguStack:SetStackCount(jinguStack:GetStackCount() + 1)
 		--print(jinguStack:GetStackCount())
+		
 		if not target.OverHeadJingu then 
 			target.OverHeadJingu = ParticleManager:CreateParticle(keys.particle, PATTACH_OVERHEAD_FOLLOW, target)
 			ParticleManager:SetParticleControl(target.OverHeadJingu, 0, target:GetAbsOrigin())
@@ -41,6 +63,13 @@ function CheckJingu(keys)
 		ParticleManager:SetParticleControl(target.OverHeadJingu, 1, Vector(0,jinguStack:GetStackCount(),0))
 		
 		if jinguStack:GetStackCount() == ability:GetTalentSpecialValueFor("required_hits") then
+			--shiny explosion particles on caster
+			local startPfx = ParticleManager:CreateParticle("particles/units/heroes/hero_monkey_king/monkey_king_quad_tap_start.vpcf", PATTACH_ABSORIGIN_FOLLOW, caster)
+			ParticleManager:SetParticleControl(startPfx, 0, caster:GetAbsOrigin())
+			ParticleManager:ReleaseParticleIndex(startPfx)
+			
+			EmitSoundOn("Hero_MonkeyKing.IronCudgel", caster)
+			
 			local jinguBuff = ability:ApplyDataDrivenModifier(caster, caster, "modifier_jingu_mastery_activated", {})
 			ability:ApplyDataDrivenModifier(caster, caster, "modifier_jingu_mastery_activated_damage", {})
 			jinguBuff:SetStackCount(ability:GetTalentSpecialValueFor("charges"))
@@ -55,8 +84,6 @@ function CheckJingu(keys)
 end
 
 function JinguOverheadDestroy(keys)
-	local caster = keys.caster
-	local ability = keys.ability
 	local target = keys.target
 	
 	ParticleManager:DestroyParticle(target.OverHeadJingu, false)


### PR DESCRIPTION
the code i added was more or less copied from my own, which i know works. i dont have the time to test it now.

1. added activation sound and particle
2. moved lifesteal and hitPfx to lua because previously jingu could lifesteal on buildings. jingu damage should apply to buildings, but not the lifesteal.
3. added missing flags to jingu melee (didnt add to ranged because i dont think its supposed to be pickable?)
4. fixed jingu counter not being refreshed on each attack

didnt commit the following, but i could if you want.
i have this in my own jingu, run from "OnAbilityExecuted" in the registerer modifier
this function (with a small edit to JinguHit) makes boundless strike treat the custom jingu as it would real jingu

	-- "boundless strike will consume one charge of jingu regardless of if it hits any units"
	--not perfect. if you use boundless with 1 stack left it will apply debuff to all units hit, in this specfic case none should get debuff
	function BoundlessDecrement( keys )
		local ability = keys.event_ability
		local caster = keys.caster
		if not ability:GetName() == "monkey_king_boundless_strike" then
			return
		end
	
		--decrement stacks
		local jingu = caster:FindModifierByNameAndCaster("modifier_jingu_mastery_buff", caster)
		if jingu then
			jingu:DecrementStackCount()
			if jingu:GetStackCount() <= 0 then
				jingu:Destroy()
			end
		end

		--this script runs JUST before the hit script, we use this to tell the hit script to not decrement the stacks
		caster.BoundlessCast = true
		Timers:CreateTimer(0.03, function()
			caster.BoundlessCast = nil
		end)
	end