### PR TITLE
Doom devour talent

### DIFF
--- a/src/game/scripts/npc/abilities/dota/doom_bringer_devour_lod.txt
+++ b/src/game/scripts/npc/abilities/dota/doom_bringer_devour_lod.txt
@@ -6,7 +6,7 @@
 		"AbilityBehavior" "DOTA_ABILITY_BEHAVIOR_UNIT_TARGET | DOTA_ABILITY_BEHAVIOR_DONT_RESUME_ATTACK"
 		"AbilityUnitTargetTeam" "DOTA_UNIT_TARGET_TEAM_ENEMY"
 		"AbilityUnitTargetType" "DOTA_UNIT_TARGET_CREEP"
-		"AbilityUnitTargetFlags" "DOTA_UNIT_TARGET_FLAG_NOT_CREEP_HERO | DOTA_UNIT_TARGET_FLAG_NOT_ANCIENTS"
+		"AbilityUnitTargetFlags" "DOTA_UNIT_TARGET_FLAG_NOT_CREEP_HERO"
 		"AbilityCooldown" "70 60 50 40"
 		"AbilityManaCost" "60"
 		"AbilityCastRange" "300"

--- a/src/game/scripts/vscripts/abilities/hero_doom.lua
+++ b/src/game/scripts/vscripts/abilities/hero_doom.lua
@@ -17,6 +17,10 @@ function CreepGold ( keys )
 	local ability = keys.ability
 	local gold = ability:GetLevelSpecialValueFor("devour_gold", ability:GetLevel()) - 1
 
+	if caster:HasAbility("special_bonus_unique_doom_3") and caster:FindAbilityByName("special_bonus_unique_doom_3"):GetLevel() > 0 then
+		gold = gold + ability:GetSpecialValueFor("value")
+	end
+
 	if caster:IsAlive() then
 	    caster:ModifyGold(gold, false, 0)
 	    
@@ -50,12 +54,21 @@ function DevourCheck( keys )
 	local pID = caster:GetPlayerID()
 	local player = PlayerResource:GetPlayer( pID )
 
+	if not caster:HasAbility("special_bonus_unique_doom_2") or caster:FindAbilityByName("special_bonus_unique_doom_2"):GetLevel() == 0 then
+		if keys.target:IsAncient() then
+			caster:Interrupt()
+			-- Play Error Sound
+			EmitSoundOnClient("General.CastFail_InvalidTarget_Hero", player)
+			util:DisplayError(pID, "#UF_FAIL_ANCIENT")
+		end
+	end
+
 	if caster:HasModifier(modifier) then
 		caster:Interrupt()
 
 		-- Play Error Sound
 		EmitSoundOnClient("General.CastFail_InvalidTarget_Hero", player)
-		util:DisplayError(pID, "#devour_denied")
+		util:DisplayError(pID, "You can't eat with your mouth full")
 		--FireGameEvent('custom_error_show', {player_ID = pID, _error = "You can't eat with your mouth full"})
 	end
 end

--- a/src/game/scripts/vscripts/abilities/hero_doom.lua
+++ b/src/game/scripts/vscripts/abilities/hero_doom.lua
@@ -59,7 +59,7 @@ function DevourCheck( keys )
 			caster:Interrupt()
 			-- Play Error Sound
 			EmitSoundOnClient("General.CastFail_InvalidTarget_Hero", player)
-			util:DisplayError(pID, "#UF_FAIL_ANCIENT")
+			util:DisplayError(pID, "#only_target_creeps")
 		end
 	end
 
@@ -68,7 +68,7 @@ function DevourCheck( keys )
 
 		-- Play Error Sound
 		EmitSoundOnClient("General.CastFail_InvalidTarget_Hero", player)
-		util:DisplayError(pID, "You can't eat with your mouth full")
+		util:DisplayError(pID, "#devour_denied")
 		--FireGameEvent('custom_error_show', {player_ID = pID, _error = "You can't eat with your mouth full"})
 	end
 end

--- a/src/localization/addon_english.txt
+++ b/src/localization/addon_english.txt
@@ -10057,6 +10057,7 @@
     "DOTA_Tooltip_ability_zuus_arc_lightning_op_radius"                               "JUMP RANGE:"
 
     "devour_denied"                                                                    "Cannot eat with your mouth full"
+    "only_target_creeps"                            "Cannot consume Ancients"
     
 
 }


### PR DESCRIPTION
This needs localization for the error message on devouring ancients without the talent.
Something like:
"only_target_creeps" "Can't target ancients"
should be added, I don't have sourcetree access now :(