### PR TITLE
balance change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Master of Magic now requires 3 charges to refresh an ultimate
 - Added New Option to Free Ability mutator: Random Survivial Ability
 - Added the newer flesh heaps to the Free Random Flesh Heap mutator
+- Reduced stun multiplier on anti-stun
 
 ## 9.0
 - Fury of the immortals: Cooldown increased by 5 seconds, non-stacking damage decreased, stun duration decreased by 0.5

--- a/src/game/scripts/npc/abilities/custom/bash_reflect.txt
+++ b/src/game/scripts/npc/abilities/custom/bash_reflect.txt
@@ -27,7 +27,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-                "duration"                                              "6"
+                "duration"                                              "13"
             }
             "02"
             {

--- a/src/game/scripts/npc/abilities/custom/bash_reflect.txt
+++ b/src/game/scripts/npc/abilities/custom/bash_reflect.txt
@@ -27,12 +27,12 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-                "duration"                                              "13"
+                "duration"                                              "6"
             }
             "02"
             {
                 "var_type"                                             "FIELD_FLOAT"
-                "duration_multiplier"                                              "100 140 160 200"
+                "duration_multiplier"                                              "50 75 100 125"
             }
         }
         "ReduxFlags"                                                           "dota_custom"


### PR DESCRIPTION
Bash-reflect : We changed it into anti-stun. 200% multiplier is way too strong. change it to 125%. and decrease the duration.

Its crazy when against player with active stun ability. 2sec -> 4sec reflect.