### PR TITLE
Survival balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 * 
 - Drasticallyed lowered the effectiveness of spell resistance survival
 - Increased Balanced Build Bonus to 1500
+- Reduced rate for following survivals: Spelll Boost, Spell Amp
+- Improved rate for following survivals: Agi, Attack Speed, Critical Strike, Int
 
 ## 9.0
 - Fury of the immortals: Cooldown increased by 5 seconds, non-stacking damage decreased, stun duration decreased by 0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 - Essence Aura is now a single player ability
 - Anti-Bash Ability is now Anti-Stun and works on active and passive abilities
 - Flesh Heap can now gain stacks from kills by summons (e.g. Nimbus Cloud)
-*
 - Added many more survival abilities
 - Roshanify Aegis inventory bug fixed.
 - Roshanify OP version added for singleplayer.
@@ -26,6 +25,8 @@ All notable changes to this project will be documented in this file.
 - Added the newer flesh heaps to the Free Random Flesh Heap mutator
 - Reduced stun multiplier on anti-stun
 - Double Creeps vote requires 70% of player agreement, not 50% anymore
+* 
+- Drasticallyed lowered the effectiveness of spell resistance survival
 
 ## 9.0
 - Fury of the immortals: Cooldown increased by 5 seconds, non-stacking damage decreased, stun duration decreased by 0.5

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_agi_survival.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_agi_survival.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"2.0 4.0 6.0 8.0"
+        				"bonus"						"1.5 3.0 4.5 6.0"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_agi_survival.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_agi_survival.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"1.0 2.0 3.0 4.0"
+        				"bonus"						"2.0 4.0 6.0 8.0"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_attack_speed.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_attack_speed.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"2.0 4.0 6.0 8.0"
+        				"bonus"						"4.0 6.0 8.0 10.0"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_attack_speed.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_attack_speed.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"4.0 6.0 8.0 10.0"
+        				"bonus"						"4.5 6.0 7.5 9.0"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_critical.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_critical.txt
@@ -18,7 +18,7 @@
             "02"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"chance"						"15.0"
+        				"chance"						"25.0"
             }
         }
         "ReduxFlags"                                                           "crit | attack_modifier"

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_int_survival.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_int_survival.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"1.0 2.0 3.0 4.0"
+        				"bonus"						"2.0 4.0 6.0 8.0"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_magic_resistance.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_magic_resistance.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"2.0 4.0 6.0 8.0"
+        				"bonus"						"1.0 1.5 2.0 2.5"
             }
         }
         "ReduxFlags"                                                           "tank"

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_spell_boost.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_spell_boost.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"2.0 3.0 4.0 5.0"
+        				"bonus"						"1.0 1.5 2.0 2.5"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_spell_boost.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_spell_boost.txt
@@ -13,7 +13,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"1.0 1.5 2.0 2.5"
+        				"bonus"						"1.0 2.0 3.0 4.0"
             }
         }
         "ReduxFlags"                                                           ""

--- a/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_spell_vamp.txt
+++ b/src/game/scripts/npc/abilities/spelllab/spell_lab_survivor_spell_vamp.txt
@@ -17,7 +17,7 @@
             "01"
             {
                 "var_type"                                             "FIELD_FLOAT"
-        				"bonus"						"2.5 5.0 7.5 10.0"
+        				"bonus"						"2.0 4.0 6.0 8.0"
             }
         }
         "ReduxFlags"                                                           "tank"

--- a/src/game/scripts/vscripts/abilities/spell_lab/survivor/critical.lua
+++ b/src/game/scripts/vscripts/abilities/spell_lab/survivor/critical.lua
@@ -23,7 +23,7 @@ function spell_lab_survivor_critical_modifier:GetModifierPreAttack_CriticalStrik
 if self:GetParent():PassivesDisabled() then return 0 end
 	local chance = self:GetAbility():GetSpecialValueFor("chance")
 	if (math.random(0,100) > chance) then return 0 end
-  return self:GetStackCount()
+  return （self:GetStackCount()+100）
 end
 
 function spell_lab_survivor_critical_modifier:OnDeath(kv)


### PR DESCRIPTION
people just stay in fountain and waiting for the bonus. For the bonuses that can have effect at fountain(Cooldown spell amp), it has to be weak. For bonus that work in fight, should be stronger. Otherwise we should just make them troll combo with any global skills. Or, we make them stack much faster, but only grow when you are in enemies visions. for now, I'll just do some value balance.