### PR TITLE
Balance change for Illusionist

### DIFF
--- a/src/game/scripts/npc/abilities/lia/illusionist_agility_paws.txt
+++ b/src/game/scripts/npc/abilities/lia/illusionist_agility_paws.txt
@@ -11,17 +11,17 @@
             "01"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "bonus_agility"                                        "1 2 3 4"
+                "bonus_agility"                                        "4"
             }
             "02"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "prt_bonus"                                            "10"
+                "prt_bonus"                                            "10 15 20 25"
             }
             "03"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "max_bonus"                                            "200"
+                "max_bonus"                                            "40 60 80 100"
             }
         }
         "Modifiers"

--- a/src/game/scripts/npc/abilities/lia/illusionist_mastery_of_illusions.txt
+++ b/src/game/scripts/npc/abilities/lia/illusionist_mastery_of_illusions.txt
@@ -35,7 +35,7 @@
             "05"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "count_illusion"                                       "2 4 6"
+                "count_illusion"                                       "3"
             }
             "06"
             {
@@ -45,7 +45,7 @@
             "07"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "outgoing_damage"                                      "-60 -50 -40"
+                "outgoing_damage"                                      "-40 -30 -20"
             }
             "08"
             {
@@ -55,7 +55,7 @@
             "09"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "outgoing_damage_tooltip"                              "40 50 60"
+                "outgoing_damage_tooltip"                              "60 70 80"
             }
         }
         "precache"

--- a/src/game/scripts/npc/abilities/lia/illusionist_mastery_of_illusions.txt
+++ b/src/game/scripts/npc/abilities/lia/illusionist_mastery_of_illusions.txt
@@ -35,12 +35,12 @@
             "05"
             {
                 "var_type"                                             "FIELD_INTEGER"
-                "count_illusion"                                       "3"
+                "count_illusion"                                       "2 4 6"
             }
             "06"
             {
                 "var_type"                                             "FIELD_FLOAT"
-                "life_illusion"                                        "5 6 7"
+                "life_illusion"                                        "10 12 14"
             }
             "07"
             {


### PR DESCRIPTION
I saw players doing this build just stay in jungle and wait for 200 agility.
So I made it stacks faster but lower the maximum.


Lower the maximum agility into 100
slightly increased rate of growth. 
Old: 10% * 4 agility  
New: 25% *4 agility
