### PR TITLE
Give people time to reconnect.

### DIFF
--- a/src/game/scripts/vscripts/pregame.lua
+++ b/src/game/scripts/vscripts/pregame.lua
@@ -123,12 +123,13 @@ function Pregame:init()
     self.optionVoteSettings = {
         banning = {
             onselected = function(self)
+                OptionManager:SetOption('banningTime', 60)
                 self:setOption('lodOptionBanning', 3, true)
                 self:setOption('lodOptionBanningMaxBans', 3, true)
                 self:setOption('lodOptionBanningMaxHeroBans', 2, true)
             end,
             onunselected = function(self)
-                OptionManager:SetOption('banningTime', 25)
+                OptionManager:SetOption('banningTime', 60)
                 self:setOption('lodOptionBanning', 3, true)
                 self:setOption('lodOptionBanningMaxBans', 2, true)
                 self:setOption('lodOptionBanningMaxHeroBans', 1, true)


### PR DESCRIPTION
I brought this issue up a while ago and it got the highest priority tag.
This will enable people who get disconnected at start of banning to reconnect before wisp spawning has started and thus they get to spawn.
I think this might be one of the reasons why LOD official is still played in countries with worse pc/internet because it doesn't have this problem.