### PR TITLE
Update axe_berserkers_call_op.txt

### DIFF
--- a/src/game/scripts/npc/abilities/dota/axe_berserkers_call_op.txt
+++ b/src/game/scripts/npc/abilities/dota/axe_berserkers_call_op.txt
@@ -11,7 +11,7 @@
         "SpellDispellableType"          "SPELL_DISPELLABLE_NO"
         "FightRecapLevel"               "1"
         "AbilitySound"                  "Hero_Axe.Berserkers_Call"
-        "ReduxCost"                                                            "120"
+        "ReduxCost"                                                            "500"
         "ReduxFlags"                                                           "tank"
         "ReduxPerks"                                                           "rage"
         "AbilityCastRange"                                                     "5000 10000 15000 25000"


### PR DESCRIPTION
A global 40 second duration taunt with 60 seconds cooldown is a bit too annoying for people who play points mode with single player abilities enabled.