### PR TITLE
neutral_items.txt

### DIFF
--- a/src/game/scripts/npc/neutral_items.txt
+++ b/src/game/scripts/npc/neutral_items.txt
@@ -14,89 +14,90 @@
 		
 		"items"
 		{
-			"item_elixer"					  "1"
-			"item_ocean_heart"				  "1"
 			"item_keen_optic"				  "1"
-			"item_broom_handle"				  "1"
-			"item_faded_broach"				  "1"	
 			"item_poor_mans_shield"			  "1"
-			"item_mango_tree"				  "1"
-			"item_royal_jelly"				  "1"
 			"item_iron_talon"				  "1"
-			"item_arcane_ring"				  "1"
-			"item_recipe_ironwood_tree"		  "1"
+			"item_ironwood_tree"			  "1"
+			"item_royal_jelly"				  "1"
+			"item_mango_tree"				  "1"
+			"item_ocean_heart"				  "1"
+			"item_broom_handle"				  "1"
 			"item_trusty_shovel"			  "1"
-			"item_philosophers_stone"		  "1"
+			"item_faded_broach"				  "1"
+			"item_arcane_ring"				  "1"
 			"item_grove_bow"				  "1"
-			"item_nether_shawl"				  "1"
-			"item_imp_claw"					  "1"
-			"item_essence_ring"				  "1"
 			"item_vampire_fangs"			  "1"
-			"item_pupils_gift"				  "1"
-			"item_dragon_scale"				  "1"
-			"item_clumsy_net"				  "1"
 			"item_ring_of_aquila"			  "1"
-			"item_recipe_vambrace"			  "1"
+			"item_pupils_gift"				  "1"
+			"item_imp_claw"					  "1"
+			"item_philosophers_stone"		  "1"
+			"item_nether_shawl"				  "1"
+			"item_dragon_scale"				  "1"
+			"item_essence_ring"				  "1"
+			"item_vambrace"					  "1"
+			"item_clumsy_net"				  "1"
 			"item_repair_kit"				  "1"
-			"item_quickening_charm"			  "1"
-			"item_greater_faerie_fire"		  "1"
-			"item_enchanted_quiver"			  "1"
 			"item_craggy_coat"				  "1"
+			"item_greater_faerie_fire"		  "1"
+			"item_quickening_charm"			  "1"
+			"item_spider_legs"				  "1"
+			"item_enchanted_quiver"			  "1"
 			"item_paladin_sword"			  "1"
 			"item_orb_of_destruction"		  "1"
-			"item_minotaur_horn"			  "1"
-			"item_third_eye"				  "1"
 			"item_titan_sliver"				  "1"
-			"item_helm_of_the_undying"		  "1"
+			"item_spy_gadget"				  "1"
 			"item_mind_breaker"				  "1"
-			"item_spider_legs"				  "1"
-			"item_ninja_gear"				  "1"
-			"item_panic_button"				  "1"
-			"item_the_leveller"				  "1"
 			"item_witless_shako"			  "1"
-			"item_havoc_hammer"				  "1"
-			"item_princes_knife"			  "1"
-			"item_recipe_trident"			  "1"
-			"item_illusionsts_cape"			  "1"
 			"item_timeless_relic"			  "1"
 			"item_spell_prism"				  "1"
+			"item_princes_knife"			  "1"
 			"item_flicker"					  "1"
-			"item_spy_gadget"				  "1"
-			"item_fusion_rune"				  "1"
-			"item_phoenix_ash"				  "1"
+			"item_ninja_gear"				  "1"
+			"item_illusionsts_cape"			  "1"
+			"item_havoc_hammer"				  "1"
+			"item_panic_button"				  "1"
+			"item_the_leveller"				  "1"
+			"item_minotaur_horn"			  "1"
+			"item_force_boots"				  "1"
+			"item_desolator_2"				  "1"
 			"item_seer_stone"				  "1"
+			"item_mirror_shield"			  "1"
 			"item_apex"						  "1"
 			"item_ballista"					  "1"
 			"item_woodland_striders"		  "1"
-			"item_desolator_2"				  "1"
+			"item_recipe_trident"			  "1"
 			"item_demonicon"				  "1"
-			"item_recipe_fallen_sky"		  "1"
+			"item_fallen_sky"				  "1"
 			"item_pirate_hat"				  "1"
 			"item_ex_machina"				  "1"
-			"item_force_boots"				  "1"
-			"item_mirror_shield"			  "1"
 		}
 	}
 	"2"
 	{
 		"drop_rates"
 		{
-			"00:00"
+			"0:00"
 			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
+				"0" "14"
+				"1" "14"
+				"2" "14"
+				"3" "14"
 			}
 		}
 		
 		"items"
 		{
-			"item_elixer"					  "1"
-			"item_ocean_heart"				  "1"
 			"item_keen_optic"				  "1"
-			"item_broom_handle"				  "1"
-			"item_faded_broach"				  "1"	
 			"item_poor_mans_shield"			  "1"
+			"item_iron_talon"				  "1"
+			"item_ironwood_tree"			  "1"
+			"item_royal_jelly"				  "1"
+			"item_mango_tree"				  "1"
+			"item_ocean_heart"				  "1"
+			"item_broom_handle"				  "1"
+			"item_trusty_shovel"			  "1"
+			"item_faded_broach"				  "1"
+			"item_arcane_ring"				  "1"
 		}
 	}
 	"3"
@@ -105,20 +106,26 @@
 		{
 			"5:00"
 			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
+				"0" "10"
+				"1" "10"
+				"2" "10"
+				"3" "10"
 			}
 		}
 
 		"items"
 		{
-			"item_mango_tree"				  "1"
-			"item_royal_jelly"				  "1"
-			"item_iron_talon"				  "1"
-			"item_arcane_ring"				  "1"
-			"item_recipe_ironwood_tree"		  "1"
-			"item_trusty_shovel"			  "1"
+			"item_grove_bow"				  "1"
+			"item_vampire_fangs"			  "1"
+			"item_ring_of_aquila"			  "1"
+			"item_pupils_gift"				  "1"
+			"item_imp_claw"					  "1"
+			"item_philosophers_stone"		  "1"
+			"item_nether_shawl"				  "1"
+			"item_dragon_scale"				  "1"
+			"item_essence_ring"				  "1"
+			"item_vambrace"			  "1"
+			"item_clumsy_net"				  "1"
 		}
 	}
 	"4"
@@ -127,20 +134,26 @@
 		{
 			"10:00"
 			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
+				"0" "10"
+				"1" "10"
+				"2" "10"
+				"3" "10"
 			}
 		}
 
 		"items"
 		{
-			"item_philosophers_stone"		  "1"
-			"item_grove_bow"				  "1"
-			"item_nether_shawl"				  "1"
-			"item_imp_claw"					  "1"
-			"item_essence_ring"				  "1"
-			"item_vampire_fangs"			  "1"
+			"item_repair_kit"				  "1"
+			"item_craggy_coat"				  "1"
+			"item_greater_faerie_fire"		  "1"
+			"item_quickening_charm"			  "1"
+			"item_spider_legs"				  "1"
+			"item_enchanted_quiver"			  "1"
+			"item_paladin_sword"			  "1"
+			"item_orb_of_destruction"		  "1"
+			"item_titan_sliver"				  "1"
+			"item_spy_gadget"				  "1"
+			"item_mind_breaker"				  "1"
 		}
 	}
 	"5"
@@ -149,20 +162,26 @@
 		{
 			"15:00"
 			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
+				"0" "10"
+				"1" "10"
+				"2" "10"
+				"3" "10"
 			}
 		}
 
 		"items"
 		{
-			"item_pupils_gift"				  "1"
-			"item_dragon_scale"				  "1"
-			"item_clumsy_net"				  "1"
-			"item_ring_of_aquila"			  "1"
-			"item_recipe_vambrace"			  "1"
-			"item_repair_kit"				  "1"
+			"item_witless_shako"			  "1"
+			"item_timeless_relic"			  "1"
+			"item_spell_prism"				  "1"
+			"item_princes_knife"			  "1"
+			"item_flicker"					  "1"
+			"item_ninja_gear"				  "1"
+			"item_illusionsts_cape"			  "1"
+			"item_havoc_hammer"				  "1"
+			"item_panic_button"				  "1"
+			"item_the_leveller"				  "1"
+			"item_minotaur_horn"			  "1"
 		}
 	}
 	"6"
@@ -171,131 +190,27 @@
 		{
 			"20:00"
 			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
+				"0" "10"
+				"1" "10"
+				"2" "10"
+				"3" "10"
 			}
 		}
 
 		"items"
 		{
-			"item_quickening_charm"			  "1"
-			"item_greater_faerie_fire"		  "1"
-			"item_enchanted_quiver"			  "1"
-			"item_craggy_coat"				  "1"
-			"item_paladin_sword"			  "1"
-			"item_orb_of_destruction"		  "1"
-		}
-	}
-	"7"
-	{
-		"drop_rates"
-		{
-			"25:00"
-			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
-			}
-		}
-
-		"items"
-		{
-			"item_minotaur_horn"			  "1"
-			"item_third_eye"				  "1"
-			"item_titan_sliver"				  "1"
-			"item_helm_of_the_undying"		  "1"
-			"item_mind_breaker"				  "1"
-			"item_spider_legs"				  "1"
-		}
-	}
-	"8"
-	{
-		"drop_rates"
-		{
-			"30:00"
-			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
-			}
-		}
-
-		"items"
-		{
-			"item_ninja_gear"				  "1"
-			"item_panic_button"				  "1"
-			"item_the_leveller"				  "1"
-			"item_witless_shako"			  "1"
-			"item_havoc_hammer"				  "1"
-			"item_princes_knife"			  "1"
-		}
-	}
-	"9"
-	{
-		"drop_rates"
-		{
-			"35:00"
-			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
-			}
-		}
-
-		"items"
-		{
-			"item_recipe_trident"			  "1"
-			"item_illusionsts_cape"			  "1"
-			"item_timeless_relic"			  "1"
-			"item_spell_prism"				  "1"
-			"item_flicker"					  "1"
-			"item_spy_gadget"				  "1"
-		}
-	}
-	"10"
-	{
-		"drop_rates"
-		{
-			"40:00"
-			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
-			}
-		}
-
-		"items"
-		{
-			"item_fusion_rune"				  "1"
-			"item_phoenix_ash"				  "1"
-			"item_seer_stone"				  "1"
-			"item_apex"						  "1"
-			"item_ballista"					  "1"
-			"item_woodland_striders"		  "1"
-		}
-	}
-	"11"
-	{
-		"drop_rates"
-		{
-			"45:00"
-			{
-				"0" "9"
-				"1" "6"
-				"2" "3"
-			}
-		}
-
-		"items"
-		{
+			"item_force_boots"				  "1"
 			"item_desolator_2"				  "1"
+			"item_seer_stone"				  "1"
+			"item_mirror_shield"			  	  "1"
+			"item_apex"					  "1"
+			"item_ballista"					  "1"
+			"item_woodland_striders"		    	  "1"
+			"item_recipe_trident"			   	  "1"
 			"item_demonicon"				  "1"
-			"item_recipe_fallen_sky"		  "1"
+			"item_fallen_sky"		  	  "1"
 			"item_pirate_hat"				  "1"
 			"item_ex_machina"				  "1"
-			"item_force_boots"				  "1"
-			"item_mirror_shield"			  "1"
 		}
 	}
 }


### PR DESCRIPTION
Updated this text file to reflect new neutral items after valve changes. These items are left in the valve grouping.

Previous file has smaller groups spanning over a larger time frame. Could be modified to suit.